### PR TITLE
Connect HubSpot OAuth to User Account

### DIFF
--- a/app/controllers/hubspot_controller.rb
+++ b/app/controllers/hubspot_controller.rb
@@ -1,7 +1,77 @@
+require 'uri'
+require 'net/http'
+require 'json'
+
 class HubspotController < ApplicationController
-  def connect
+  before_action :authenticate_user!
+  skip_before_action :authenticate_user!, only: [:callback]
+
+ def connect
+state = SecureRandom.hex(20)
+Rails.cache.write("hubspot_oauth_#{state}", current_user.id, expires_in: 10.minutes)
+
+redirect_to "https://app.hubspot.com/oauth/authorize" \
+            "?client_id=#{ENV['HUBSPOT_CLIENT_ID']}" \
+            "&redirect_uri=#{ENV['HUBSPOT_REDIRECT_URI']}" \
+            "&scope=#{CGI.escape(ENV['HUBSPOT_SCOPES'])}" \
+            "&state=#{state}",
+            allow_other_host: true
+end
+
+ 
+def callback
+  Rails.logger.debug "HubSpot callback params: #{params.inspect}"
+
+  user_id = Rails.cache.read("hubspot_oauth_#{params[:state]}")
+  user = User.find_by(id: user_id)
+
+  if user_id.nil? || user.nil?
+    Rails.logger.warn "Invalid or expired HubSpot state token: #{params[:state]}"
+    redirect_to new_user_session_path, alert: "Session expired. Please try connecting again."
+    return
   end
 
-  def callback
+  Rails.cache.delete("hubspot_oauth_#{params[:state]}")
+
+  if params[:code].present?
+    response = exchange_code_for_tokens(params[:code])
+    Rails.logger.debug "HubSpot token exchange response: #{response.inspect}"
+
+    if response['access_token']
+      user.update!(
+        hubspot_access_token: response['access_token'],
+        hubspot_refresh_token: response['refresh_token'],
+        hubspot_token_expires_at: Time.current + response['expires_in'].to_i.seconds
+      )
+
+      Rails.logger.info "HubSpot connected successfully for user #{user.email}"
+      sign_in(user) unless current_user == user
+      redirect_to home_index_path, notice: "HubSpot connected successfully!"
+    else
+      Rails.logger.error "Failed to retrieve HubSpot tokens: #{response.inspect}"
+      redirect_to home_index_path, alert: "Failed to connect with HubSpot."
+    end
+  else
+    Rails.logger.warn "No code param found in HubSpot callback"
+    redirect_to home_index_path, alert: "Authorization code missing."
   end
+end
+
+
+
+  private
+    def exchange_code_for_tokens(code)
+    uri = URI("https://api.hubapi.com/oauth/v1/token")
+
+    res = Net::HTTP.post_form(uri, {
+      grant_type: "authorization_code",
+      client_id: ENV['HUBSPOT_CLIENT_ID'],
+      client_secret: ENV['HUBSPOT_CLIENT_SECRET'],
+      redirect_uri: ENV['HUBSPOT_REDIRECT_URI'],
+      code: code
+    })
+
+    JSON.parse(res.body)
+  end
+
 end

--- a/app/controllers/hubspot_controller.rb
+++ b/app/controllers/hubspot_controller.rb
@@ -1,0 +1,7 @@
+class HubspotController < ApplicationController
+  def connect
+  end
+
+  def callback
+  end
+end

--- a/app/controllers/hubspot_controller.rb
+++ b/app/controllers/hubspot_controller.rb
@@ -6,72 +6,81 @@ class HubspotController < ApplicationController
   before_action :authenticate_user!
   skip_before_action :authenticate_user!, only: [:callback]
 
- def connect
-state = SecureRandom.hex(20)
-Rails.cache.write("hubspot_oauth_#{state}", current_user.id, expires_in: 10.minutes)
+  def connect
+    state = SecureRandom.hex(20)
+    Rails.cache.write("hubspot_oauth_#{state}", current_user.id, expires_in: 10.minutes)
 
-redirect_to "https://app.hubspot.com/oauth/authorize" \
-            "?client_id=#{ENV['HUBSPOT_CLIENT_ID']}" \
-            "&redirect_uri=#{ENV['HUBSPOT_REDIRECT_URI']}" \
-            "&scope=#{CGI.escape(ENV['HUBSPOT_SCOPES'])}" \
-            "&state=#{state}",
-            allow_other_host: true
-end
+    redirect_to 'https://app.hubspot.com/oauth/authorize' \
+                "?client_id=#{ENV.fetch('HUBSPOT_CLIENT_ID', nil)}" \
+                "&redirect_uri=#{ENV.fetch('HUBSPOT_REDIRECT_URI', nil)}" \
+                "&scope=#{CGI.escape(ENV.fetch('HUBSPOT_SCOPES', nil))}" \
+                "&state=#{state}",
+                allow_other_host: true
+  end
 
- 
-def callback
+ def callback
   Rails.logger.debug "HubSpot callback params: #{params.inspect}"
 
-  user_id = Rails.cache.read("hubspot_oauth_#{params[:state]}")
-  user = User.find_by(id: user_id)
-
-  if user_id.nil? || user.nil?
-    Rails.logger.warn "Invalid or expired HubSpot state token: #{params[:state]}"
-    redirect_to new_user_session_path, alert: "Session expired. Please try connecting again."
-    return
-  end
-
-  Rails.cache.delete("hubspot_oauth_#{params[:state]}")
+  @user = fetch_user_from_state(params[:state])
+  return handle_invalid_state unless @user
 
   if params[:code].present?
-    response = exchange_code_for_tokens(params[:code])
-    Rails.logger.debug "HubSpot token exchange response: #{response.inspect}"
-
-    if response['access_token']
-      user.update!(
-        hubspot_access_token: response['access_token'],
-        hubspot_refresh_token: response['refresh_token'],
-        hubspot_token_expires_at: Time.current + response['expires_in'].to_i.seconds
-      )
-
-      Rails.logger.info "HubSpot connected successfully for user #{user.email}"
-      sign_in(user) unless current_user == user
-      redirect_to home_index_path, notice: "HubSpot connected successfully!"
-    else
-      Rails.logger.error "Failed to retrieve HubSpot tokens: #{response.inspect}"
-      redirect_to home_index_path, alert: "Failed to connect with HubSpot."
-    end
+    process_token_exchange(params[:code])
   else
-    Rails.logger.warn "No code param found in HubSpot callback"
-    redirect_to home_index_path, alert: "Authorization code missing."
+    Rails.logger.warn 'No code param found in HubSpot callback'
+    redirect_to home_index_path, alert: 'Authorization code missing.'
   end
 end
 
-
-
   private
-    def exchange_code_for_tokens(code)
-    uri = URI("https://api.hubapi.com/oauth/v1/token")
+
+  def exchange_code_for_tokens(code)
+    uri = URI('https://api.hubapi.com/oauth/v1/token')
 
     res = Net::HTTP.post_form(uri, {
-      grant_type: "authorization_code",
-      client_id: ENV['HUBSPOT_CLIENT_ID'],
-      client_secret: ENV['HUBSPOT_CLIENT_SECRET'],
-      redirect_uri: ENV['HUBSPOT_REDIRECT_URI'],
-      code: code
-    })
+                                grant_type: 'authorization_code',
+                                client_id: ENV.fetch('HUBSPOT_CLIENT_ID', nil),
+                                client_secret: ENV.fetch('HUBSPOT_CLIENT_SECRET', nil),
+                                redirect_uri: ENV.fetch('HUBSPOT_REDIRECT_URI', nil),
+                                code: code
+                              })
 
     JSON.parse(res.body)
   end
+
+  def fetch_user_from_state(state)
+  user_id = Rails.cache.read("hubspot_oauth_#{state}")
+  Rails.cache.delete("hubspot_oauth_#{state}")
+  User.find_by(id: user_id)
+end
+
+
+def handle_invalid_state
+  Rails.logger.warn "Invalid or expired HubSpot state token: #{params[:state]}"
+  redirect_to new_user_session_path, alert: 'Session expired. Please try connecting again.'
+end
+
+def process_token_exchange(code)
+  response = exchange_code_for_tokens(code)
+  Rails.logger.debug "HubSpot token exchange response: #{response.inspect}"
+
+  if response['access_token']
+    update_user_tokens(@user, response)
+    Rails.logger.info "HubSpot connected successfully for user #{@user.email}"
+    sign_in(@user) unless current_user == @user
+    redirect_to home_index_path, notice: 'HubSpot connected successfully!'
+  else
+    Rails.logger.error "Failed to retrieve HubSpot tokens: #{response.inspect}"
+    redirect_to home_index_path, alert: 'Failed to connect with HubSpot.'
+  end
+end
+
+def update_user_tokens(user, response)
+  user.update!(
+    hubspot_access_token: response['access_token'],
+    hubspot_refresh_token: response['refresh_token'],
+    hubspot_token_expires_at: Time.current + response['expires_in'].to_i.seconds
+  )
+end
 
 end

--- a/app/helpers/hubspot_helper.rb
+++ b/app/helpers/hubspot_helper.rb
@@ -1,0 +1,2 @@
+module HubspotHelper
+end

--- a/app/views/hubspot/callback.html.erb
+++ b/app/views/hubspot/callback.html.erb
@@ -1,0 +1,2 @@
+<h1>Hubspot#callback</h1>
+<p>Find me in app/views/hubspot/callback.html.erb</p>

--- a/app/views/hubspot/connect.html.erb
+++ b/app/views/hubspot/connect.html.erb
@@ -1,0 +1,2 @@
+<h1>Hubspot#connect</h1>
+<p>Find me in app/views/hubspot/connect.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+get '/hubspot/connect', to: 'hubspot#connect', as: :hubspot_connect
+get '/hubspot/callback', to: 'hubspot#callback', as: :hubspot_callback
+
 
   devise_for :users, controllers: {
     omniauth_callbacks: 'users/omniauth_callbacks'

--- a/db/migrate/20250711203810_add_hubspot_fields_to_users.rb
+++ b/db/migrate/20250711203810_add_hubspot_fields_to_users.rb
@@ -1,0 +1,7 @@
+class AddHubspotFieldsToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :hubspot_access_token, :string
+    add_column :users, :hubspot_refresh_token, :string
+    add_column :users, :hubspot_token_expires_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_11_192512) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_11_203810) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -41,6 +41,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_11_192512) do
     t.string "google_token"
     t.string "google_refresh_token"
     t.datetime "token_expires_at"
+    t.string "hubspot_access_token"
+    t.string "hubspot_refresh_token"
+    t.datetime "hubspot_token_expires_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/controllers/hubspot_controller_test.rb
+++ b/test/controllers/hubspot_controller_test.rb
@@ -1,12 +1,12 @@
-require "test_helper"
+require 'test_helper'
 
 class HubspotControllerTest < ActionDispatch::IntegrationTest
-  test "should get connect" do
+  test 'should get connect' do
     get hubspot_connect_url
     assert_response :success
   end
 
-  test "should get callback" do
+  test 'should get callback' do
     get hubspot_callback_url
     assert_response :success
   end

--- a/test/controllers/hubspot_controller_test.rb
+++ b/test/controllers/hubspot_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class HubspotControllerTest < ActionDispatch::IntegrationTest
+  test "should get connect" do
+    get hubspot_connect_url
+    assert_response :success
+  end
+
+  test "should get callback" do
+    get hubspot_callback_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
**Description**

This PR integrates HubSpot OAuth authentication into the app, allowing users to securely connect their HubSpot CRM accounts and store credentials for future API access.

**Changes Made:**
Added new user fields:
- hubspot_access_token
- hubspot_refresh_token
- hubspot_token_expires_at

Implemented HubspotController with:
- connect action: Redirects user to HubSpot OAuth with dynamic state and requested scopes.
- callback action: Handles the OAuth callback, exchanges code for tokens, stores tokens securely, and logs user back in.
- Used Rails.cache with a state param for improved OAuth security (prevents CSRF and session loss on redirect).
- Added logging for easier debugging and traceability.